### PR TITLE
Увеличение производительности методом усечения лишних байтов

### DIFF
--- a/frontend/css/adaptive.scss
+++ b/frontend/css/adaptive.scss
@@ -55,50 +55,6 @@
   }
 }
 
-@media screen and (max-height: 530px) {
-  #padorupadoru {
-    width: 100%;
-  }
-  #container {
-    padding-right: 40px;
-  }
-  #rightbar {
-    padding-top: 0px;
-    //width: 100%;
-    top: 0px;
-    width: 40px;
-    //top: calc(100% - 40px);
-    //flex-direction: row;
-
-    #rightbar_menu_top, #rightbar_menu_bottom {
-      //display: flex;
-
-      .rightbar-item a {
-        width: 40px;
-        height: 40px;
-
-        i {
-          font-size: 0.8em;
-        }
-
-        .new-comments {
-          top: 20px;
-          left: 23px;
-        }
-      }
-
-      .delim-top {
-        padding-top: 20px;
-        //padding-left: 20px;
-      }
-
-      .user_item {
-        display: none;
-      }
-    }
-  }
-}
-
 @media screen and (max-width: 530px) {
   #padorupadoru {
     width: 100%;

--- a/frontend/css/base.scss
+++ b/frontend/css/base.scss
@@ -8,7 +8,7 @@ body {
   line-height: 18px;
   color: $text-color;
   background: $background-image;
-  background-blend-mode: screen;
+  background-blend-mode: normal;
   //padding-top: 200px;
   padding-top: 0px;
   transition: top .2s, padding-top .2s, padding .2s;

--- a/frontend/css/bootstrap/assets/stylesheets/bootstrap/_navbar.scss
+++ b/frontend/css/bootstrap/assets/stylesheets/bootstrap/_navbar.scss
@@ -91,10 +91,6 @@
 .navbar-fixed-bottom {
   .navbar-collapse {
     max-height: $navbar-collapse-max-height;
-
-    @media (max-device-width: $screen-xs-min) and (orientation: landscape) {
-      max-height: 200px;
-    }
   }
 }
 

--- a/frontend/css/common.scss
+++ b/frontend/css/common.scss
@@ -267,17 +267,6 @@
   display: none;
 }
 
-@media screen and (max-height: 500px) {
-  .toolbar {
-    top: 0;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-}
-
 @media screen and (max-width: 800px) {
   .toolbar {
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.51);


### PR DESCRIPTION
С существенной вероятностью, фризы на андроиде вызваны бесполезной перекомпоновкой страницы при открытии софт-клавиатуры. В нынешних условиях щетаю целесообразным просто удалить реагирующие на высоту экрана твики, поскольку проблем они создают гораздо больше, чем решают.